### PR TITLE
automatic_runner: runs tests based on 1 pytest call and inits_hardwar…

### DIFF
--- a/runner/automatic_runner.py
+++ b/runner/automatic_runner.py
@@ -15,32 +15,11 @@ from runner import helpers
 helpers.init_logger()
 
 
-def collect_tests_and_init_hardware(module_name):
-    collector = TestCollector()
-    pytest.main(['--collect-only', module_name], plugins=[collector])
-
-    tests = collector.collected
-    for test in tests:
-        logging.info(f"initing hardware for test {test.nodeid}")
-        test.hardware_config = hardware_initializer.init_hardware(test.obj.__hardware_reqs)
-    return tests
-
-
 def run_test_module(module_name):
-    # TODO: I dont like how this runs pytest twice. There has got to be a way to collect, init_hardware and then continue
-    #  running the already collected tests. look up pytest hooks or somn.
-    logging.info("collecting tests and initing hardware..")
-    initialized_tests = collect_tests_and_init_hardware(module_name)
-    logging.info("done collecting and initing...")
-    tests_config = [[f'{os.path.dirname(test.fspath.strpath)}/{os.path.basename(test.nodeid)}', f'--sut_config={test.hardware_config}']
-                    for test in initialized_tests]
-    logging.info("running tests really...")
-    for idx, test_config in enumerate(tests_config):
-        pytest_args = ['-s', '-n 1', f'--html=report{idx}.html', '--self-contained-html']
-        test_config.extend(pytest_args)
-        logging.info(f"pytest args: {test_config}")
-        res = pytest.main(test_config)
-    logging.info("done running tests!")
+    # TODO: this needs to run in new process
+    pytest_args = [module_name, '-s', '-n 1', f'--html=report.html', '--self-contained-html']
+    logging.info(f"pytest args: {pytest_args}")
+    res = pytest.main(pytest_args)
     return res
 
 

--- a/tests/aio_tests/conftest.py
+++ b/tests/aio_tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from infra.model.base_config import BaseConfig
 from infra.model.host import Host
-from runner import helpers
+from runner import helpers, hardware_initializer
 
 #import sys
 #sys.stdout = sys.stderr
@@ -45,11 +45,16 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope='session')
+@pytest.hookimpl()
+def pytest_runtest_setup(item):
+    # TODO: I cant run 2 tests with 1 hardware without reinitializing it.
+    hardware_config = hardware_initializer.init_hardware(item.function.__hardware_reqs)
+    item.function.__initialized_hardware = json.loads(hardware_config)
+
+
 def base_config(request):
     print("initing base config..")
-    config = json.loads(request.config.getoption('--sut_config'))
-    base = BaseConfig.fromDict(config, DefaultFactoryMunch)
+    base = BaseConfig.fromDict(request.function.__initialized_hardware, DefaultFactoryMunch)
     base.host = Host(base.host)
     try:
         helpers.connect_via_running_docker(base)


### PR DESCRIPTION
…e in pytest hook

This is much better than previously I ran pytest to collect the tests
and then I had to init_hardware, and then I had to re-run pytest with
inited hardware_setup. This way a pytest hook jumps in after collecting
the tests and inits hardware on its own. Much better.