### PR TITLE
base_plugin/start_tunnel: added param to allow forcing same port

### DIFF
--- a/automation/automation_infra/plugins/base_plugin.py
+++ b/automation/automation_infra/plugins/base_plugin.py
@@ -13,8 +13,12 @@ class TunneledPlugin(object):
         self._forward_server = None
         self.local_bind_port = None
         
-    def start_tunnel(self, remote, port):
-        self._forward_server, self.local_bind_port = forward.start_tunnel(remote, port, self._host.SSH.get_transport())
+    def start_tunnel(self, remote, port, force_same_port=False):
+        if not force_same_port:
+            self._forward_server, self.local_bind_port = forward.start_tunnel(remote, port, self._host.SSH.get_transport())
+        else:
+            self._forward_server, self.local_bind_port = forward.start_tunnel(
+                remote, port, self._host.SSH.get_transport(), port)
 
     def stop_tunnel(self):
         self._forward_server.shutdown()

--- a/infra/model/forward.py
+++ b/infra/model/forward.py
@@ -69,13 +69,12 @@ class ForwardServer(SocketServer.ThreadingTCPServer):
     allow_reuse_address = True
 
 
-def start_tunnel(remote_host, remote_port, transport):
+def start_tunnel(remote_host, remote_port, transport, local_port=get_open_port()):
     class SubHander(Handler):
         chain_host = remote_host
         chain_port = remote_port
         ssh_transport = transport
 
-    local_port = get_open_port()
     forward_server = ForwardServer(("", local_port), SubHander)
     server_thread = threading.Thread(target=forward_server.serve_forever, daemon=True)
     server_thread.start()


### PR DESCRIPTION
The param allows starting a tunnel and forcing the local_bind_port to
be the same as the remote target port. This is necessary for at least
the kafka plugin (along with having kafka.tls.ai 127.0.0.1 in the hosts)
to communicate tunnelled through proxy containers.