### PR TITLE
Feature/remove vm shadow state

### DIFF
--- a/lab/vms/libvirt_wrapper.py
+++ b/lab/vms/libvirt_wrapper.py
@@ -42,6 +42,21 @@ class LibvirtWrapper(object):
             vm.destroy()
         logging.info("VM %s destroyed", name)
 
+    def status(self, name):
+        libvirt_state_to_state = {libvirt.VIR_DOMAIN_NOSTATE  : "unknown",
+                                  libvirt.VIR_DOMAIN_RUNNING  : "on",
+                                  libvirt.VIR_DOMAIN_BLOCKED  : "fail",
+                                  libvirt.VIR_DOMAIN_PAUSED   : "on",
+                                  libvirt.VIR_DOMAIN_SHUTDOWN : "off",
+                                  libvirt.VIR_DOMAIN_SHUTOFF  : "off",
+                                  libvirt.VIR_DOMAIN_CRASHED  : "fail",
+                                  libvirt.VIR_DOMAIN_PMSUSPENDED : "on"}
+        with self._libvirt_connection() as connection:
+            vm = connection.lookupByName(name)
+            state = vm.state()[0]
+            logging.info("VM state is %s - %s", state, libvirt_state_to_state[state])
+            return libvirt_state_to_state[state]
+
     def kill_by_name(self, name):
         logging.debug("killimg vm %s", name)
         with self._libvirt_connection() as connection:

--- a/lab/vms/test/allocator_test.py
+++ b/lab/vms/test/allocator_test.py
@@ -68,7 +68,6 @@ async def test_allocate_machine_happy_case(event_loop, mock_libvirt, mock_image_
     await tested.allocate_vm("sasha_image1", memory_gb=1, networks=["bridge"], num_cpus=2, num_gpus=1)
     assert len(tested.vms) == 1
     vm = tested.vms['sasha-vm-0']
-    assert vm['status'] == 'on'
     _verify_vm_valid(tested, vm, expected_vm_name="sasha-vm-0",
                      expected_base_image="/home/sasha_king.qcow",
                      expected_gpus=gpu1,
@@ -250,15 +249,12 @@ async def test_start_stop_machine(event_loop, mock_libvirt, mock_image_store):
     await alloc.allocate_vm("sasha_image1", memory_gb=1, networks=["bridge"], num_cpus=2, num_gpus=1)
     assert len(alloc.vms) == 1
     assert 'sasha-vm-0' in alloc.vms
-    assert alloc.vms['sasha-vm-0']['status'] == 'on'
 
     await manager.stop_vm(alloc.vms["sasha-vm-0"])
-    assert alloc.vms['sasha-vm-0']['status'] == "off"
     mock_libvirt.poweroff_vm.assert_called_once()
 
     start_count = mock_libvirt.start_vm.call_count
     await manager.start_vm(alloc.vms["sasha-vm-0"])
-    assert alloc.vms['sasha-vm-0']['status'] == "on"
     assert mock_libvirt.start_vm.call_count == start_count + 1
 
 
@@ -269,6 +265,7 @@ async def test_machine_info(event_loop, mock_libvirt, mock_image_store):
     mock_image_store.clone_qcow = asyncmock.AsyncMock(return_value="/home/sasha_king.qcow")
     mock_libvirt.dhcp_lease_info.return_value = {'52:54:00:8d:c0:07': ['192.168.122.186'],
                                                  '52:54:00:8d:c0:08': ['192.168.122.187']}
+    mock_libvirt.status.return_value = "on"
 
     manager = vm_manager.VMManager(event_loop, mock_libvirt, mock_image_store)
     alloc = allocator.Allocator(macs, gpu1, manager, "sasha", max_vms=1, paravirt_device="eth0", sol_base_port=1000)
@@ -280,6 +277,7 @@ async def test_machine_info(event_loop, mock_libvirt, mock_image_store):
     assert 'sasha-vm-0' in alloc.vms
     vm_info = await manager.info(alloc.vms['sasha-vm-0'])
     mock_libvirt.dhcp_lease_info.assert_called_once_with("sasha-vm-0")
+    mock_libvirt.status.assert_called_once_with("sasha-vm-0")
     assert len(vm_info['disks']) == 2
     assert vm_info['status'] == 'on'
     assert vm_info['dhcp'] == {'52:54:00:8d:c0:07': ['192.168.122.186'],

--- a/lab/vms/test/test_rest.py
+++ b/lab/vms/test/test_rest.py
@@ -37,12 +37,12 @@ async def test_vm_list(mock_libvirt, mock_image_store, aiohttp_client, loop):
     gpu1 = _generate_device(1)
     macs = _generate_macs(1)
     mock_image_store.clone_qcow = asyncmock.AsyncMock(return_value="/home/sasha_king.qcow")
+    mock_libvirt.status.return_value = 'on'
     manager = vm_manager.VMManager(loop, mock_libvirt, mock_image_store)
     alloc = allocator.Allocator(macs, gpu1, manager, "sasha", max_vms=1, paravirt_device="eth0", sol_base_port=1000)
     await alloc.allocate_vm("sasha_image1", memory_gb=1, networks=["bridge"], num_cpus=2, num_gpus=1)
     assert len(alloc.vms) == 1
-    vm = alloc.vms['sasha-vm-0']
-    assert vm['status'] == 'on'
+    assert 'sasha-vm-0' in alloc.vms
 
     app = web.Application()
     rest.HyperVisor(alloc, image_store, app)
@@ -63,12 +63,12 @@ async def test_vm_info(mock_libvirt, mock_image_store, aiohttp_client, loop):
     mock_image_store.clone_qcow = asyncmock.AsyncMock(return_value="/home/sasha_king.qcow")
     mock_libvirt.dhcp_lease_info.return_value = {'52:54:00:8d:c0:07': ['192.168.122.186', '192.168.122.187'],
                                                  '52:54:00:8d:c0:08': ['192.168.122.188']}
+    mock_libvirt.status.return_value = 'on'
     manager = vm_manager.VMManager(loop, mock_libvirt, mock_image_store)
     alloc = allocator.Allocator(macs, gpu1, manager, "sasha", max_vms=1, paravirt_device="eth0", sol_base_port=1000)
     await alloc.allocate_vm("sasha_image1", memory_gb=1, networks=["bridge"], num_cpus=2, num_gpus=1)
     assert len(alloc.vms) == 1
-    vm = alloc.vms['sasha-vm-0']
-    assert vm['status'] == 'on'
+    assert 'sasha-vm-0' in alloc.vms
 
     app = web.Application()
     rest.HyperVisor(alloc, image_store, app)
@@ -101,5 +101,4 @@ async def test_vm_allocate(mock_libvirt, mock_image_store, aiohttp_client, loop)
                                             "disks" : []})
     assert resp.status == 200
     assert len(alloc.vms) == 1
-    vm = alloc.vms['sasha-vm-0']
-    assert vm['status'] == 'on'
+    assert 'sasha-vm-0' in alloc.vms

--- a/lab/vms/test/vm_manager_test.py
+++ b/lab/vms/test/vm_manager_test.py
@@ -19,6 +19,7 @@ def mock_image_store():
 async def test_network_info_not_failing(event_loop, mock_libvirt, mock_image_store):
     tested = vm_manager.VMManager(event_loop, mock_libvirt, mock_image_store)
     mock_libvirt.dhcp_lease_info.side_effect = Exception("exception")
+    mock_libvirt.status.return_value = "on"
 
     vm_images = [{"serial": "s1",
                   "device_name": "dev1",


### PR DESCRIPTION
Purpose of the PR:

Currently vm status is managed in shadow state, i.e. we keep track of
"on"/"off" commands for vms and store in memory that status that we
"guess". This can lead to incorrect statuses for the vm, for example if
it was manually shut down (not via our API). In order to avoid storing
shadow state of the vm we result to "bit slower" but more bullet proof
method to obtain vm status from libvirt itself. This should prevent
inconsistent states between whan hypervisor this and what is the actual
state of the vm
