### PR TITLE
vm-cli: print valid json as commands output.

### DIFF
--- a/hypervisor_cli.py
+++ b/hypervisor_cli.py
@@ -2,6 +2,7 @@
 import requests
 import argparse
 import functools
+import json
 
 
 def _do_create(args):
@@ -80,6 +81,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     result = commands[args.command](args)
     if result.ok:
-        print(result.json())
+        print(json.dumps(result.json()))
     else:
         print("Command failed status: %s" %result.status_code)


### PR DESCRIPTION
Currently json printed by cli is invalid. an attempt to parse it
with jq for example yiels in following error:
./hypervisor_cli.py --allocator=localhost:8080 list | jq
parse error: Invalid numeric literal at line 1, column 7

This is because output contains single quote which is invalid. Solution
is simply to print "string" representation of json which prints json in
valid format