### PR TITLE
 Fixed bug in pytest_automation_infra/helpers.py

### DIFF
--- a/pytest_automation_infra/helpers.py
+++ b/pytest_automation_infra/helpers.py
@@ -66,7 +66,7 @@ def remove_proxy_container(connected_ssh_module):
         logging.info("removed successfully!")
         return True
     except SSHCalledProcessError as e:
-        if 'No such container' not in e.stderr:
+        if ('No such container' not in e.stderr) and ('No such container' not in e.stdout):
             raise e
         logging.info("nothing to remove")
 


### PR DESCRIPTION
 remove_proxy_container would raise error in a case which it shouldn't

 We would throw an error in case the container didn't exist even though
 we should skip throwing the error and contiune running.
 This would happen because when attempting to remove an existing ssh
 container before creating a new one would throw the No such container
 error to the stdout and we would only look for it in the stderr.