### PR TITLE
forward: changed start_tunnel to receive ssh_plugin

### DIFF
--- a/automation_infra/plugins/base_plugin.py
+++ b/automation_infra/plugins/base_plugin.py
@@ -17,13 +17,13 @@ class TunneledPlugin(object):
         if force_same_port:
             try:
                 self._forward_server, self.local_bind_port = forward.start_tunnel(
-                    remote, port, self._host.SSH.get_transport(), port)
+                    remote, port, self._host.SSH, port)
             except OSError:
                 self._forward_server, self.local_bind_port = forward.start_tunnel(remote, port,
-                                                                                  self._host.SSH.get_transport())
+                                                                                  self._host.SSH)
         else:
             self._forward_server, self.local_bind_port = forward.start_tunnel(remote, port,
-                                                                              self._host.SSH.get_transport())
+                                                                              self._host.SSH)
 
     def stop_tunnel(self):
         self._forward_server.shutdown()


### PR DESCRIPTION
instead of transport. This is to fix a bug that the transport object
would become inactive and then the tunnel would fail. So getting a
new transport object each time from the ssh_plugin solves this problem.