### PR TITLE
Bug/fix-snippet-from-file

### DIFF
--- a/automation_infra/utils/pypacker.py
+++ b/automation_infra/utils/pypacker.py
@@ -18,7 +18,9 @@ class PythonPacker(object):
     def from_file(cls, filepath, outfile=None):
         packer = cls()
         with open(filepath, 'r') as fp:
-            packer._pack(fp, fp.read(), outfile)
+            script = fp.read()
+            fp.seek(0)
+            packer._pack(fp, script, outfile)
         return packer
 
     @classmethod


### PR DESCRIPTION
when the script creates an egg from a given file path it's first read the file,
then pass to the compressing function the file content and the buffer.
since it read the file the passed buffer is empty. 
we need to seek to the starting place in order to make it work.