### PR TITLE
TMTNNFR-79: fixing up docker-compose and added instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include Makefile.common
 
+RESOURCES_CONFIG_FILE ?= ./example.resources.yml
+
 .PHONY: help
 help: _help
 
@@ -7,6 +9,14 @@ help: _help
 tests: ## run all tests
 	@cd ./hwprovisioner && make tests
 	@bash ./run_tests.sh
+
+
+.PHONY: run-server
+run-server: ## run allocate, a resource manager etc ...
+ifeq ("$(wildcard ./hwprovisioner/resourcemanager/$(RESOURCES_CONFIG_FILE))","")
+  $(error RESOURCES_CONFIG_FILE '$(RESOURCES_CONFIG_FILE)' not found in ./hwprovisioner/resourcemanager/)
+endif
+	@RESOURCES_CONFIG_FILE=${RESOURCES_CONFIG_FILE} docker-compose up
 
 .PHONY: lint
 lint: _lint ## run generic linters

--- a/README.md
+++ b/README.md
@@ -374,3 +374,18 @@ make test-lint-docker     # run only docker linter
 ## hwprovisoner architecture
 
 https://anyvision.atlassian.net/wiki/spaces/PROD/pages/1558806855
+
+## run backend services
+
+These steps will allow you to run allocate, redis and a resource manager:
+
+It is recommended you start by copying
+`./hwprovisioner/resourcemanager/example.resources.yml` to
+`./hwprovisioner/resourcemanager/resources.yml` and update the content to
+match the resources you have.
+
+
+```sh
+# note: RESOURCES_CONFIG_FILE is relative to ./hwprovisioner/resourcemanager/
+RESOURCES_CONFIG_FILE=./resources.yml make run-server
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - REDIS_DB=0
     depends_on:
       - redis
+    working_dir: /src
     command: watchmedo auto-restart --patterns="*.py;*.yaml;*.yml" --recursive -- python -m 'webapp.app' serve
   resourcemanager:
     image: anyvision-hwprovisioner-resourcemanager
@@ -34,11 +35,12 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=0
-      - ALLOCATE_API=http://allocate:8080/api/
-      - CONFIG_FILE=./example.resources.yml
+      - ALLOCATE_API=http://allocate:8080/
+      - CONFIG_FILE=${RESOURCES_CONFIG_FILE:-./example.resources.yml}
     depends_on:
       - redis
       - allocate
+    working_dir: /src
     command: watchmedo auto-restart --patterns="*.py;*.yaml;*.yml" --recursive -- python -m 'webapp.app' serve
   redis:
     image: redis:5.0.7


### PR DESCRIPTION
**What does this PR do?**

Fixes an issue with docker-compose and adds some instructions.

**How should I test this?**

Follow the instructions in the README to get the backend running (redis, allocate and a resource manager). Then run your pytest against it. Some sample commands and code if you need it:

```python
import logging
import sys

from pytest_automation_infra.helpers import hardware_config

logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)

LOGGER = logging.getLogger(__name__)


def __run_cmd(base_config, cmd):
    """
    run commands using subprocess
    """
    LOGGER.info("running: %s" % cmd)
    res = base_config.hosts.benchmark_machine.SshDirect.execute(cmd)
    LOGGER.info(res)
    return res


@hardware_config(hardware={"benchmark_machine": {"cpu": ">=1"}})
def test_simple(base_config):
    """
    execute tests on the belfast machine
    """
    __run_cmd(base_config, "uname -a")
```

```sh
python3 -m pytest -p pytest_automation_infra --provisioner=http://localhost:8080/ -o log_cli=true -o log_cli_level=INFO test.py
```