### PR TITLE
enttrypoint: supress group 'docker' does not exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ echo 'source /environ ' >> "${userhome}"/.bashrc
 
 # We need to adjust docker group according to GID on the host machine
 # so that we will be able to run docker inside docker
-groupmod -g "${DOCKER_GROUP_ID}" docker
+# groupmod -g "${DOCKER_GROUP_ID}" docker
 
 if [ ${username} == "root" ]; then
     echo "running as root"


### PR DESCRIPTION
supress warnning message groupmod: group 'docker' does not exist
if we will need docker in docker support in the future I will return this line and fix missing `DOCKER_GROUP_ID` var