### PR TITLE
containerize.sh: add -t (tty) to docker run

### DIFF
--- a/containerize.sh
+++ b/containerize.sh
@@ -210,7 +210,7 @@ function run_docker () {
     env_cmd+="-e PYTHONPATH=${python_path}"
 
     # mount source code in same location as in host
-    cmd="docker run --name ${NAME} --privileged  --rm $mount_cmd $env_cmd"
+    cmd="docker run -t --name ${NAME} --privileged  --rm $mount_cmd $env_cmd"
 
     cmd+=" $(_read_passed_environment)"
 


### PR DESCRIPTION
in order to support colorize (basically for jenkins) I need to pass
to docker run the flag -t : Allocate a pseudo-tty
no risk for those who runs only containerize.sh