### PR TITLE
requirements.txt added mock dependencies

### DIFF
--- a/docker_build/requirements.txt
+++ b/docker_build/requirements.txt
@@ -1,2 +1,7 @@
 rpyc
 confluent_kafka
+google
+protobuf
+numpy
+opencv-python==4.2.0.32
+grpcio==1.21.1


### PR DESCRIPTION
these dependencies can not be passed in a
snippet egg, therefore they must be already
installed in the container.