### PR TITLE
Added boto3 to requirements

### DIFF
--- a/docker_build/requirements.txt
+++ b/docker_build/requirements.txt
@@ -4,4 +4,5 @@ google
 protobuf
 numpy
 opencv-python
+boto3
 grpcio==1.21.1


### PR DESCRIPTION
since the mock-egg can't archive the full boto3 library.