### PR TITLE
ssh_direct.py: add PubkeyAuthentication=no option

### DIFF
--- a/automation_infra/plugins/ssh_direct.py
+++ b/automation_infra/plugins/ssh_direct.py
@@ -125,9 +125,9 @@ class SshDirect(object):
             key_path_on_source = self._install_private_key(dest_host.keyfile, self._host)
             prefix = "scp -i %s" % key_path_on_source
         else:
-            prefix = "sshpass -p %s scp" % dest_host.password
+            prefix = "sshpass -p %s scp -o PubkeyAuthentication=no" % dest_host.password
 
-        scp_script = '%(prefix)s -q  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\
+        scp_script = '%(prefix)s -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\
                      -r %(source)s root@%(dest_ip)s:%(dest)s' % dict(prefix=prefix,
                                                                      source=source_file_or_dir,
                                                                      dest_ip=dest_host.ip,
@@ -139,7 +139,7 @@ class SshDirect(object):
         if self._host.keyfile:
             prefix = "scp -i %s" % self._host.keyfile
         else:
-            prefix = "sshpass -p %s scp" % self._host.password
+            prefix = "sshpass -p %s scp -o PubkeyAuthentication=no" % self._host.password
 
         cmd_template = '%(prefix)s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\
                         -r %(localpath)s %(username)s@%(hostname)s:%(remotepath)s'
@@ -154,7 +154,7 @@ class SshDirect(object):
         if self._host.keyfile:
             prefix = "scp -i %s" % self._host.keyfile
         else:
-            prefix = "sshpass -p %s scp" % self._host.password
+            prefix = "sshpass -p %s scp -o PubkeyAuthentication=no" % self._host.password
 
         cmd_template = '%(prefix)s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\
                         -r %(username)s@%(hostname)s:%(remotepath)s %(localpath)s'


### PR DESCRIPTION
issue: in case that user has passphrase on his pem file for ssh login but he is using
only password in the hardware.yaml, ssh direct download and upload methods will hang 

cause: methods with ssh upload/download which using scp will not work because they will hang to wait for key passphrase

solution: add to scp for password only in  hardware.yaml (not for pem key) new option PubkeyAuthentication=no which is Force SSH client to use password authentication instead of public key in case that user has passphrase to his pem file but he is using only password

issue: https://anyvision.atlassian.net/browse/TMTNNFR-169

more on:
https://makandracards.com/makandra/1326-force-ssh-client-to-use-password-authentication-instead-of-public-key