### PR TITLE
vms: avoid deleting vm in case of ip renew timeout failure.

### DIFF
--- a/lab/vms/allocator.py
+++ b/lab/vms/allocator.py
@@ -26,6 +26,18 @@ class Allocator(object):
         self.private_network = private_network
         self.sol_base_port = sol_base_port
 
+    async def _try_restore_ip(self, vm_data, net_iface, max_retries):
+        last_error = None
+        for i in range(max_retries):
+            try:
+                await self.vm_manager.dhcp_manager.reallocate_ip(net_iface)
+                break
+            except TimeoutError as e:
+                logging.warning(f"try {i} Ip reallocation failed on machine {vm_data} machine might not be accessibe")
+                last_error = e
+        else:
+            raise last_error
+
     async def _try_restore_vm(self, vm_data):
         pcis_info = vm_data.get('pcis', [])
         macs_to_reserve = []
@@ -47,7 +59,9 @@ class Allocator(object):
 
             # Now lets try to reserve the ip VM previously had
             try:
-                await self.vm_manager.dhcp_manager.reallocate_ip(net_iface)
+                await self._try_restore_ip(vm_data, net_iface, max_retries=10)
+            except TimeoutError:
+                logging.error(f"Ip reallocation failed on machine {vm_data} machine might not be accessibe" , exc_info=True)
             except Exception as e:
                 raise VMRestoreException(vm_data, f'Failed to init networks of vm {vm_data}') from e
 

--- a/lab/vms/test/allocator_test.py
+++ b/lab/vms/test/allocator_test.py
@@ -387,3 +387,32 @@ async def test_restore_machine_fail_to_restore_network(event_loop, mock_libvirt,
     # We still must have all resources that allocator was initializes with
     assert tested.mac_addresses == macs
     assert tested.gpus_list == gpu1
+
+
+@pytest.mark.asyncio
+async def test_restore_machine_fail_to_restore_network_timeout_success(event_loop, mock_libvirt, mock_image_store, mock_nbd_provisioner, mock_cloud_init, mock_dhcp_handler):
+    gpu1 = _generate_device(2)
+    macs = _generate_macs(2)
+    mock_dhcp_handler.allocate_ip = mock.AsyncMock(return_value = "1.1.1.1")
+    manager = vm_manager.VMManager(event_loop, mock_libvirt, mock_image_store, mock_nbd_provisioner, mock_cloud_init, mock_dhcp_handler)
+    mock_image_store.clone_qcow.return_value = "/tmp/image.qcow"
+    old_allocator = allocator.Allocator(copy.copy(macs), copy.copy(gpu1), manager, "sasha", max_vms=1, paravirt_device="eth0", sol_base_port=1000)
+    await old_allocator.allocate_vm("sasha_image1", memory_gb=1, base_image_size=None, networks=["bridge"], num_cpus=2, num_gpus=1)
+    assert len(old_allocator.vms) == 1
+    assert 'sasha-vm-0' in old_allocator.vms
+    old_vm_info = await manager.info(old_allocator.vms['sasha-vm-0'])
+
+    # Get json with which machine was created
+    vm_def = mock_libvirt.define_vm.call_args.args[0].json
+    # Now set load to return same json
+    mock_libvirt.load_lab_vms.return_value = [munch.Munch(vm_def)]
+
+    # Now recreate the allocator
+    mock_dhcp_handler.reallocate_ip = mock.AsyncMock(side_effect = TimeoutError("Failed to allocate ip"))
+    tested = allocator.Allocator(macs, gpu1, manager, "sasha", max_vms=1, paravirt_device="eth0", sol_base_port=1000)
+    await tested.restore_vms()
+    assert len(tested.vms) == 1
+    assert 'sasha-vm-0' in tested.vms
+    restored_vm_info = await manager.info(old_allocator.vms['sasha-vm-0'])
+
+    assert restored_vm_info == old_vm_info


### PR DESCRIPTION
Currently if we fail to renew the ip due to the timeout we delete the
vm. We were assuming that networking resource will be available and work
in the office environment. However this is not so true :)
In one of our offices we have network drops at DHCP and sometime it just
does not respond. In this case during restore vm we will just delete
probably good vm.
As a temporary measure we will retry 10 times to reallocate ip
and after that even in case of failure we will just proceed and not
delete the vm.