### PR TITLE
testing: allow to execute run_test from arbitary directory.

### DIFF
--- a/containerize.sh
+++ b/containerize.sh
@@ -7,7 +7,7 @@ DOCKERIZE_FORCE_BUILD=${DOCKERIZE_FORCE_BUILD:-0}
 V=${V:=0}
 
 # Absolute path to this script
-SCRIPT=$(readlink -f "$0")
+SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 # Absolute path to the script directory
 script_dir=$(dirname "$SCRIPT")
 
@@ -206,6 +206,7 @@ function run_docker () {
     mount_cmd+=" "
 
     python_path=$(build_python_path $mount_path)
+    python_path+=":$script_dir"
 
     env_cmd+="-e PYTHONPATH=${python_path} "
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -46,7 +46,8 @@ function main () {
     cmd=$(update_received_cmd "$cmd")
     echo "after updating received command: $cmd"
     echo "running command: ./containerize.sh $cmd"
-    ./containerize.sh "$cmd"
+    local script_dir=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
+    $script_dir/containerize.sh "$cmd"
 }
 
 


### PR DESCRIPTION
Currently run_test can only be run from automation infra directory.
This happens because containerize script is only searched locally.
The fix is to locate a run_test script, "assume" containerize is located at the same path as
run_test and access it from same location