### PR TITLE
pytest_automation_infra: changed clean to happen in runtest_call

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -263,7 +263,9 @@ def base_config(request):
         hb_thread.join()
 
 
-def pytest_runtest_setup(item):
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
     hosts = item.funcargs['base_config'].hosts.items()
     initializer.clean_infra_between_tests(hosts)
     logging.info(f"entering: {item}")
+    yield


### PR DESCRIPTION
There can be cases where pytest_runtest_setup is called before the
fixture setup which will cause an exception when access
funcargs['base_config'].
So the solution is to make the clean logic happen in runtest_call, which
is also the more 'correct' place to put it because we want the cleanup
to happen precisely before and after the test itself.