### PR TITLE
Revert "pytest_automation_infra: changed clean to happen in runtest_c…

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -263,9 +263,7 @@ def base_config(request):
         hb_thread.join()
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item):
+def pytest_runtest_setup(item):
     hosts = item.funcargs['base_config'].hosts.items()
     initializer.clean_infra_between_tests(hosts)
     logging.info(f"entering: {item}")
-    yield


### PR DESCRIPTION
…all"

This reverts commit 2e4c5eba46e00ed021c6e5a8f30e84d90817f0b4.
Reverted because it broke all the tests .. somehow cleaner happened in incorrect time and caused consul plugin to stopped working 