### PR TITLE
plugins/iptables.py: added rule for FORWARD chain as well as OUTPUT

### DIFF
--- a/automation_infra/plugins/ip_table.py
+++ b/automation_infra/plugins/ip_table.py
@@ -23,6 +23,7 @@ class Iptables(object):
     def activate_automation_chain(self):
         chain = self.AUTOMATION_CHAIN
         commands = [(f"iptables --check OUTPUT --jump {chain}", f"iptables --insert OUTPUT --jump {chain}"),
+                    (f"iptables --check FORWARD --jump {chain}", f"iptables --insert FORWARD --jump {chain}"),
                     (f"iptables --check {chain} --jump RETURN", f"iptables --insert {chain} --jump RETURN")]
         for try_cmd, except_cmd in commands:
             try:


### PR DESCRIPTION
Previously the iptables.block would only block communication to the
service between HRT and HUT, but really it needs to block
inter-container communication as well, so need to add the rule to the
FORWARD table as well.