### PR TITLE
rpyc: allow test to manipulate rpyc member variables.

### DIFF
--- a/automation_infra/utils/rpyc_service.py
+++ b/automation_infra/utils/rpyc_service.py
@@ -6,5 +6,6 @@ from rpyc.utils.server import ThreadedServer
 def start_service(port, loglevel, service):
     ch = logging.StreamHandler(sys.stdout)
     logging.basicConfig(level=loglevel, format='%(relativeCreated)6d %(threadName)s %(message)s', handlers=[ch])
-    server = ThreadedServer(service, hostname="0.0.0.0", port=port, protocol_config={"allow_public_attrs": True})
+    server = ThreadedServer(service, hostname="0.0.0.0", port=port, protocol_config={"allow_public_attrs": True,
+                                                                                     "allow_setattr": True})
     server.start()


### PR DESCRIPTION
Sometimes test need to set rpyc server variables. allow it to do so