### PR TITLE
pytest_runtest_setup: bugfix for exception thrown on fixture setup

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -266,6 +266,7 @@ def base_config(request):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_setup(item):
     # The yield allows the base_config fixture to be init'ed:
-    yield
+    outcome = yield
+    outcome.get_result()
     hosts = item.funcargs['base_config'].hosts.items()
     initializer.clean_infra_between_tests(hosts)


### PR DESCRIPTION
When exceptions happen in base_config fixture, they are caught by
pytest and ignored unless purposely checked. This would lead to a
KeyError in pytest_runtest_setup function when trying to access
funcargs['base_config'].
The fix is to save the outcome from the yield, and get_result. If
base_config fixture setup got an exception, the get_result raises it.