### PR TITLE
resource_manager: removed do not use docstring

### DIFF
--- a/automation_infra/plugins/resource_manager.py
+++ b/automation_infra/plugins/resource_manager.py
@@ -19,8 +19,6 @@ from infra.model import plugins
 logging.getLogger('botocore').setLevel(logging.WARN)
 
 class ResourceManager(BaseObject):
-    """NOTE: Please dont use this plugin. The proper plugin to use is in devops-automation-infra
-    repository. This is here for historical reasons only."""
     def __init__(self, host):
         super().__init__(host)
         self._client = None


### PR DESCRIPTION
We finally decided that automation_infra is the proper location for resource
manager.