### PR TITLE
TMTNNFR-214/ciissues

### DIFF
--- a/lab/vms/allocator.py
+++ b/lab/vms/allocator.py
@@ -1,4 +1,7 @@
 import logging
+import socket
+import errno
+
 from lab import NotEnoughResourceException
 from . import vm
 import asyncio
@@ -25,6 +28,7 @@ class Allocator(object):
         self.paravirt_net_device = paravirt_device
         self.private_network = private_network
         self.sol_base_port = sol_base_port
+        self.sol_used_ports = []
 
     async def _try_restore_ip(self, vm_data, net_iface, max_retries):
         last_error = None
@@ -105,8 +109,21 @@ class Allocator(object):
             machine = vm.VM(**vm_data)
             await self.vm_manager.destroy_vm(machine)
 
-    def _sol_port(self):
-        return self.sol_base_port + len(self.vms)
+    def _get_free_port(self, port, attempts=100):
+        if attempts == 0:
+            raise socket.error("Could not find any free ports")
+        if port not in self.sol_used_ports:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(("127.0.0.1", port))
+                logging.debug(f"port {port} seems free")
+                sock.close()
+                self.sol_used_ports.append(port)
+                return port
+            except socket.error as err:
+                if err.errno != errno.EADDRINUSE:
+                    raise err
+        return self._get_free_port(port + 1, attempts - 1)
 
     def _reserve_gpus(self, num_gpus):
         gpus = self.gpus_list[:num_gpus]
@@ -171,7 +188,7 @@ class Allocator(object):
             vm_index = vm_index + 1
             vm_name = "%s-vm-%d" % (self.server_name, vm_index)
         machine = vm.VM(name=vm_name, num_cpus=num_cpus, memsize=memory_gb,
-                         net_ifaces=networks, sol_port=self._sol_port(),
+                         net_ifaces=networks, sol_port=self._get_free_port(self.sol_base_port + len(self.vms)),
                          pcis=gpus, base_image=base_image,
                          disks=disks, base_image_size=base_image_size)
         self.vms[vm_name] = machine


### PR DESCRIPTION
**What does this PR do?**

Fixes various problems that were appearing in CI. Details:

TMTNNFR-214: ensure there is no sol port conflict

Again we made an assumption that base_port + len(vms) would be
sufficient for allocating the tcp service port in our VM xml definition.
This was not sufficient enough as we did not first check to see if the
port was free.

For example:
base_port = 10000
create 1 vm. it gets assigned 10000 [base_port + current vms(0)]
create 1 vm. it gets assigned 10001 [base_port + current vms(1)]
create 1 vm. it gets assigned 10002 [base_port + current vms(2)]
delete the 2nd vm (was on 10001)
create 1 vm. it gets assigned 10002 [base_port + current vms(2)]
^ this conflicts (as the last VM we created is also on this port)

This was the source of a lot of lower level errors

Why not just use memoization? It is true that we could use only memoization to
record which ports we use and then free them up. I decided not to do
this on it's own as the port could be in use by another service. This solution is
more robust. However I left in some memoization so as to avoid any race conditions (two creations attempted at near the same time)

Why not use the retry library instead of attempts? I didn't want to
include another dependency for the sake of doing something so simple



TMTNNFR-214: ensuring vm_name is free

Previously you could create VMs and they would be named as follows:
VMS-vm-0
VMS-vm-1
VMS-vm-2
etc...
where the last number was the len() of the vms. This logic was flawed as
you could remove VMS-vm-1, then attempt to create another VM which would
give you VMS-vm-2 (as there's 2 left in vms) which causes a name
conflict