### PR TITLE
containerize: fix inconsistent container environment

### DIFF
--- a/containerize.sh
+++ b/containerize.sh
@@ -198,7 +198,7 @@ function run_docker () {
 
     MOUNTS=("${HOME}/.ssh:${HOME}/.ssh"
             "/var/run/docker.sock:/var/run/docker.sock"
-            "${HOME}/.local:${HOME}/.local"
+            "${HOME}/.local/hardware.yaml:${HOME}/.local/hardware.yaml"
             "${HOME}/.docker:${HOME}/.docker"
             "${HOME}/.aws:${HOME}/.aws"
             "$MOUNT_PATH:$MOUNT_PATH"


### PR DESCRIPTION
Currently containerize environment passes $HOME/.local directory.
The problem with this approach that ubuntu includes python packages at
$HOME/.local location for example ~/.local/lib/python3.6/. So this
creates a situation that every user has "its own" libraries accessible
from containerize and run time environment is not "repeatable".
The fix is very simple, only pass hardware.yaml and not everything else
in $HOME/.local