### PR TITLE
Revert "helpers: check_for_legacy_containers on starting infra"

### DIFF
--- a/pytest_automation_infra/helpers.py
+++ b/pytest_automation_infra/helpers.py
@@ -127,18 +127,6 @@ def is_blank(connected_ssh_module):
     return False
 
 
-def check_for_legacy_containers(ssh):
-    if is_k8s(ssh):
-        return
-    container_names = ssh.execute("docker ps | tail -n +2 | awk '{print $NF}'").split()
-    if not container_names:
-        return
-    common_prefix = os.path.commonprefix(container_names)
-    if not common_prefix or common_prefix[-1] not in '_-':
-        raise Exception(f"Found containers with different prefixes: {container_names}. "
-                        f"Please prune accordingly and rerun test.")
-
-
 def init_proxy_container_and_connect(host):
     logging.debug(f"[{host}] connecting to ssh directly")
     host.SshDirect.connect()
@@ -146,7 +134,6 @@ def init_proxy_container_and_connect(host):
 
     if is_blank(host.SshDirect):
         return
-    check_for_legacy_containers(host.SshDirect)
     deploy_proxy_container(host.SshDirect)
 
     logging.debug(f"[{host}] connecting to ssh container")


### PR DESCRIPTION
This reverts commit 92c831711c4aabb0d2d18eae8df17e4a9a659385.
This causes failures on local system in case previous test is aborted in
the middle and automation proxy container is not shut down.

error log:
           Exception: Found containers with different prefixes: ['automation_proxy', 'docker-compose_collate-service_1', 'docker-compose_seaweedfs-s3_1', 'docker-compose_permission-management-service_1', 'docker-compose_seaweedfs-filer_1', 'docker-compose_seaweedfs-volume_1', 'docker-compose_consul-agent_1', 'docker-compose_seaweedfs-master_1', 'docker-compose_logrotate_1', 'docker-compose_memsql_1', 'docker-compose_zookeeper_1', 'docker-compose_postgres_1', 'docker-compose_consul_1', 'docker-compose_nginx_1', 'docker-compose_rtstreamer_1', 'docker-compose_docker-hoster_1', 'docker-compose_redis_1', 'docker-compose_kafka-hq_1', 'docker-compose_regions-service_1']. Please prune accordingly and rerun test.