### PR TITLE
TMTNNFR-265: enabling trustGuestFxFilters to allow multicast over the…

### DIFF
--- a/lab/vms/vm_template.py
+++ b/lab/vms/vm_template.py
@@ -84,13 +84,13 @@ template = '''
 
     {% for iface in machine.net_ifaces %}
     {% if iface.mode == "isolated" %}
-    <interface type='network'>
+    <interface type='network' trustGuestRxFilters='yes'>
       <mac address='{{ iface.macaddress }}'/>
       <source network='{{ iface.source }}'/>
       <model type='virtio'/>
     </interface>
     {% else %}
-    <interface type='direct'>
+    <interface type='direct' trustGuestRxFilters='yes'>
       <mac address='{{ iface.macaddress }}'/>
       <source dev='{{ iface.source }}' mode='bridge'/>
       <model type='virtio'/>


### PR DESCRIPTION
Enables multicast over the device

To test this you can run a stream from inside the VM then listen on the host.

The test I performed:

```
# inside a container on the VM
docker run --net=host --privileged --rm --entrypoint bash -ti jrottenberg/ffmpeg

# then ..
VID=https://archive.org/download/thethreeagesbusterkeaton/Buster.Keaton.The.Three.Ages.mp4
ffmpeg -stream_loop -1 -re -i $VID -c copy -f rtp_mpegts rtp://224.1.1.1:1234
```

```
# from host
sudo tcpdump port 1234 -i any
```

fix background: https://superuser.com/a/1033768