### PR TITLE
TMTNNFR-268: supporting N hosts for the hardware.yaml generator

### DIFF
--- a/dev_environment/makefiles/Makefile.hardware
+++ b/dev_environment/makefiles/Makefile.hardware
@@ -4,11 +4,20 @@ PASS ?= $(shell bash -c 'read -e -p "PASSWORD (leave empty if use pem key file):
 key_file_path ?= $(shell bash -c 'read -e -p "KEY PEM PATH (leave empty if use password): " key; echo $$key')
 CONN_FILE_PATH ?= "$${HOME}/.local/hardware.yaml"
 
+define _write_host_block
+	echo "host$1:" >> $(CONN_FILE_PATH); \
+	echo "  ip: $2" >> $(CONN_FILE_PATH); \
+	echo "  user: $(USERNAME)" >> $(CONN_FILE_PATH); \
+	echo "  password: $(PASS)" >> $(CONN_FILE_PATH); \
+	echo "  key_file_path: $(key_file_path)" >> $(CONN_FILE_PATH)
+endef
+
+
 .PHONY: set-connection-file
 set-connection-file:
 	@echo "creating connection file under: $(CONN_FILE_PATH)"
-	@echo "host:" > $(CONN_FILE_PATH)
-	@echo "  ip: $(HOST_IP)" >> $(CONN_FILE_PATH)
-	@echo "  user: $(USERNAME)" >> $(CONN_FILE_PATH)
-	@echo "  password: $(PASS)" >> $(CONN_FILE_PATH)
-	@echo "  key_file_path: $(key_file_path)" >> $(CONN_FILE_PATH)
+	@echo "---" > $(CONN_FILE_PATH)  # reset file to clean state
+	@i=0; for ip in $(shell echo $(HOST_IP) | sed "s/,/ /g"); do \
+		((i+=1)); \
+		$(call _write_host_block,$$i,$$ip); \
+	done


### PR DESCRIPTION
This change allows you to OPTIONALLY set comma separated values for the
HOST_IP value. This means that you can now run:

`HOST_IP=1.2.3.4,4.5.6.7 USERNAME=foo PASS=bar key_file_path=blah make
-f Makefile-env set-connection-file`

which will generate:

```yaml
---
host1:
  ip: 1.2.3.4
  user: pete
  password: bar
  key_file_path: blah
host2:
  ip: 4.5.6.7
  user: pete
  password: bar
  key_file_path: blah
```