### PR TITLE
automation proxy: allow multiple concurrect session and connections.

### DIFF
--- a/automation_infra/tests/basic_tests/test_tunnel.py
+++ b/automation_infra/tests/basic_tests/test_tunnel.py
@@ -1,15 +1,9 @@
 import logging
-
-import pytest
-from paramiko import SSHException
-
 from pytest_automation_infra.helpers import hardware_config
 
 
 @hardware_config(hardware={"host": {}})
 def test_tunnel(base_config):
     host = base_config.hosts.host
-    with pytest.raises(TimeoutError):
-        failed_tunnel = host.TunnelManager.get_or_create("temp", "fake", 1234)
     consul_tunnel = host.TunnelManager.get_or_create("remote", host.ip, 22)
     logging.info(f"tunnel up on: {consul_tunnel.host_port}")

--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -35,6 +35,8 @@ RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/
     && sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 300/' /etc/ssh/sshd_config \
     && sed -i 's/#UseDNS no/UseDNS yes/' /etc/ssh/sshd_config \
     && sed -i 's/#PermitTunnel no/PermitTunnel yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#MaxStartups.*/MaxStartups 512:30:1024/' /etc/ssh/sshd_config \
+    && sed -i 's/#MaxSessions.*/MaxSessions 1024/' /etc/ssh/sshd_config \
     # SSH login fix. Otherwise user is kicked off after login
     && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 


### PR DESCRIPTION
When developing debug abilities to connect gdb in runtime via tunnel to
one of the services i noticed that GDB corrupts because of our initial
"tunnel check" that was performed in 4a2d17e46ca410b6829d6a588750d2d9eaa90b11
This commit was there to solve an issue that tunnel was failing
sporadically in our tests. After futher investigation i had discovered
that the issue was actually in "concurrency" and max allowed ssh
sessions.

Soltuion is to increase those 2 to very high number to avoid such cases