### PR TITLE
host: add rsync interface to rsync files from fs to host.

### DIFF
--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     gnupg2 \
     iproute2 \
+    rsync \
   && ln -s /usr/bin/python3 /usr/local/bin/python \
   && pip3 install --upgrade pip \
   && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* \

--- a/automation_infra/plugins/ssh_direct.py
+++ b/automation_infra/plugins/ssh_direct.py
@@ -185,6 +185,16 @@ class SshDirect(object):
                                       localpath=localdir)
             subprocess.check_call(cmd, shell=True)
 
+    def rsync(self, src, dst, exclude_dirs=None):
+        if self._using_keyfile:
+            raise NotImplemented("Rsync with SSH key is not yet implemented")
+        exclude_dirs = exclude_dirs or []
+        exclude_expr = " ".join([f"--exclude {exclude_dir}" for exclude_dir in exclude_dirs])
+        prefix = f"sshpass -p {self._connection.password} rsync -ravh --delete {exclude_expr} -e \"ssh -p {self._connection.port} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\""
+        cmd = f"{prefix} {src} {self._host.user}@{self._host.ip}:{dst}"
+        subprocess.check_call(cmd, shell=True)
+
+
 
 class SSHCalledProcessError(CalledProcessError):
     def __init__(self, returncode, cmd, output=None, stderr=None, host=None):

--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -18,6 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     libxrender-dev \
     python3-pip \
     iproute2 \
+    rsync \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This interface is better to "manual" usage when we actually reuse the VM
to sync manually built binaries to the container