### PR TITLE
Add reports dir for jenkins

### DIFF
--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Currently, accuracy results saves the results graph in logs dir.
This cause the accuracy report to sit next to the logs which not make
sense.
The accuracy results graph will now saved to report dir that in the
future will contain reports from the load&configs tool that Aviad writes...