### PR TITLE
host.py: changed plugin_init_lock to RLock

### DIFF
--- a/infra/model/host.py
+++ b/infra/model/host.py
@@ -50,7 +50,7 @@ class Host(object):
         self.extra_config = host_config
         self.__plugins = {}
         self._temp_dir_counter = itertools.count()
-        self._plugins_init_lock = threading.Lock()
+        self._plugins_init_lock = threading.RLock()
 
     def _init_plugin_locked(self, name):
         if name in self.__plugins:


### PR DESCRIPTION
This is necessary because if init of a plugin happens within init of
another plugin then deadlock ensues.