### PR TITLE
infra: make an ip a must attribute in host config.

### DIFF
--- a/infra/model/host.py
+++ b/infra/model/host.py
@@ -41,6 +41,8 @@ class Host(object):
         assert (_pass and not _pem) or (_pem and not _pass), \
             "password and key are mutually exclusive (password=%s, key=%s)" % (_pass, _pem)
         self.ip = host_config.pop('ip')
+        if self.ip is None:
+            raise ValueError("Host ip cannot be None")
         self.user = host_config.pop('user')
         self.alias = host_config.pop('alias', str(random.randint(0, 999)))
         self.port = host_config.pop('port', 22)


### PR DESCRIPTION
Currently Host object is initialized even if ip is not given (failure in
allocation without proper error handling can cause ip in hardware.yaml
to be null). This of course causes test to fail in bizare locations when
trying to actually connect to the host. Exception stack track in this
case does not really suggest of a problem.
The fi is to raise proper exception in case ip is not specified