### PR TITLE
download_host_logs: specify remote log folders by name

### DIFF
--- a/automation_infra/plugins/ssh_direct.py
+++ b/automation_infra/plugins/ssh_direct.py
@@ -186,7 +186,7 @@ class SshDirect(object):
             try:
                 subprocess.check_call(cmd, shell=True)
             except:
-                logging.exception(f"exceptiong trying to download with command: {cmd}")
+                logging.exception(f"exception trying to download {dest_path} with command: {cmd}")
 
     def rsync(self, src, dst, exclude_dirs=None):
         if self._using_keyfile:

--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -330,8 +330,10 @@ def pytest_report_teststatus(report, config):
 
 def download_host_logs(host, logs_dir):
     dest_dir = os.path.join(logs_dir, host.alias)
-    paths_to_download = ['/storage/logs/', '/var/log/journal']
-    logging.info(f"Downloading logs from {host.alias} to {dest_dir}")
+    logging.info(f"remote log folders and permissions: {host.SshDirect.execute('ls /storage/logs -lh')}")
+    remote_log_folders = host.SshDirect.execute('ls /storage/logs').split()
+    paths_to_download = [*[f"/storage/logs/{folder}" for folder in remote_log_folders], '/var/log/journal']
+    logging.info(f"Downloading logs from {host.alias} to {dest_dir}. Paths to download: {paths_to_download}")
     os.makedirs(dest_dir, exist_ok=True)
     host.SshDirect.download(re.escape(dest_dir), *paths_to_download)
 


### PR DESCRIPTION
This is to help debugging cases where specific folders fail to download.