### PR TITLE
download_host_logs: download automation_proxy logs as well

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -330,9 +330,10 @@ def pytest_report_teststatus(report, config):
 
 def download_host_logs(host, logs_dir):
     dest_dir = os.path.join(logs_dir, host.alias)
-    logging.debug(f"remote log folders and permissions: {host.SshDirect.execute('ls /storage/logs -lh')}")
+    logging.debug(f"remote log folders and permissions: {host.SshDirect.execute('ls /storage/logs -lh || mkdir -p /storage/logs')}")
+    host.SshDirect.execute('docker logs automation_proxy &> /tmp/automation_proxy.log')
     remote_log_folders = host.SshDirect.execute('ls /storage/logs').split()
-    paths_to_download = [*[f"/storage/logs/{folder}" for folder in remote_log_folders], '/var/log/journal']
+    paths_to_download = [*[f"/storage/logs/{folder}" for folder in remote_log_folders], '/var/log/journal', '/tmp/automation_proxy.log']
     logging.debug(f"Downloading logs from {host.alias} to {dest_dir}. Paths to download: {paths_to_download}")
     os.makedirs(dest_dir, exist_ok=True)
     host.SshDirect.download(re.escape(dest_dir), *paths_to_download)


### PR DESCRIPTION
This is to help debug ssh connection problems, transport closed and
other stuff like that.