### PR TITLE
automation_infra client (pytest) side changes for running provisioned

### DIFF
--- a/pytest_automation_infra/hardware_initializer.py
+++ b/pytest_automation_infra/hardware_initializer.py
@@ -2,31 +2,20 @@
 """
 import logging
 import asyncio
+import os
 import time
 
 import aiohttp
+import yaml
 
 
-machine_details = {
-    "pass_machine": {
-        "ip": "192.168.21.163",
-        "user": "user",
-        "password": "pass",
-        "key_file_path": "",
-        "host_id": 123,
-        "host_type": "physical",
-        "allocation_id": "",
-    },
-    "pem_machine": {
-        "ip": "192.168.21.163",
-        "user": "root",
-        "password": "",
-        "key_file_path": "/path/to/docker_user.pem",
-        "host_id": 123,
-        "host_type": "physical",
-        "allocation_id": "",
-    },
-}
+def get_local_config(local_config_path):
+    if not os.path.isfile(local_config_path):
+        raise Exception("""local hardware_config yaml not found""")
+    with open(local_config_path, 'r') as f:
+        local_config = yaml.full_load(f)
+    logging.debug(f"local_config: {local_config}")
+    return local_config
 
 
 async def fetcher(hardware_req, provisioner, resource_wait=None):
@@ -38,55 +27,33 @@ async def fetcher(hardware_req, provisioner, resource_wait=None):
     async with aiohttp.ClientSession() as client:
         logging.debug("connecting to job queue")
         websocket = await client.ws_connect(
-            "%sapi/ws/jobs" % provisioner,
+            "http://%s/api/ws/jobs" % provisioner,
         )
         try:
             logging.debug("sending demands to job queue")
             await websocket.send_json({"data": {"demands": hardware_req}})
-            reply = await websocket.receive_json(timeout=10)
-            if "allocation_id" in reply:
-                logging.debug(f"allocation_id: {reply['allocation_id']}")
-                await websocket.send_json({
-                    "data": {"allocation_id": reply["allocation_id"]}
-                })
-                reply = await websocket.receive_json(timeout=resource_wait)
-                if "inventory_data" in reply:
-                    return {
-                        "candidate": reply["inventory_data"]["access"],
-                        "allocation_id": reply["allocation_id"]
-                    }
+            reply = await websocket.receive_json(timeout=60)
+            if reply['status'] == 'success':
+                return reply
             else:
-                logging.error("failed to set demands")
+                logging.info(f"response: {reply}")
+                raise Exception(reply['message'])
         except TimeoutError:
             logging.error("Error: timed out")
     return {}
 
 
-def init_hardware(hardware_req, provisioner=None):
+def provision_hardware(hardware_req, provisioner):
     """
     """
-    hardware = {}
+    hardware = {"machines": {}}
     if provisioner:  # provisioned mode
         logging.info(f"initing hardware with provisioner {provisioner}")
         loop = asyncio.get_event_loop()
         start = time.time()
         reply = loop.run_until_complete(fetcher(hardware_req, provisioner))
-        logging.debug("fetcher took %s seconds", time.time() - start)
-        if "candidate" in reply:
-            logging.info(f'received hardware allocation: {reply}')
-            hostname = list(hardware_req.keys())[0]
-            hardware[hostname] = reply["candidate"]
-            hardware[hostname]["alias"] = hostname
-            hardware[hostname]["allocation_id"] = reply["allocation_id"]
-        else:
-            if "reason" not in reply:
-                raise ValueError(
-                    "failed to find a resource which met your requirements"
-                )
-            raise ValueError(reply["reason"])
-    else:
-        # hardware_req is a dictionary
-        machine_names = hardware_req.keys()
-        for machine_name in machine_names:
-            hardware[machine_name] = machine_details[machine_name]
+        logging.info("fetcher took %s seconds", time.time() - start)
+        hardware['allocation_id'] = reply['allocation_id']
+        for machine_name, hardware_details in zip(hardware_req.keys(), reply['result']['hardware_details']):
+            hardware['machines'][machine_name] = hardware_details
     return hardware


### PR DESCRIPTION
Changes were requiered both on send_heartbeat and also in the
communication between client and allocator.

The whole flow of initing hardware provisioned vs local and with
different fixture scopes was refactored and made much more clear.

Also, previously the hearbeat would be sent per allocation_id, but with the
new implementation of allocator the hb needs to be send per
allocation_id. This also makes more sense bc hardware is allocated (and
deallocated) together.