### PR TITLE
pytest_automation_infra/base_config: remove teardown after yield

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -175,9 +175,7 @@ def base_config(request):
     assert hardware, "Didnt find configured_hardware in base_config fixture..."
     base = init_base_config(hardware)
     logging.info("sucessfully initialized base_config fixture")
-    yield base
-    logging.debug("tearing down base_config fixture")
-    helpers.tear_down_proxy_containers(base.hosts.items())
+    return base
 
 
 def init_cluster_structure(base_config, cluster_config):


### PR DESCRIPTION
base_config

This is unnecessary and in fact fucks up the last test run, because the
hook for fixture teardown happens before runtest_teardown, which causes
download logs to happen on a closed base_config object.

Better to leave this to be handled in runtest_teardown.