### PR TITLE
check /etc/hosts file is not blank

### DIFF
--- a/pytest_automation_infra/helpers.py
+++ b/pytest_automation_infra/helpers.py
@@ -155,6 +155,10 @@ def check_for_legacy_containers(ssh):
                         f"Please prune accordingly and rerun test.")
 
 
+def check_hosts_file(ssh):
+    assert ssh.execute("cat /etc/hosts"), "remote /etc/hosts is blank. This will cause problems for docker_hoster"
+
+
 def init_proxy_container_and_connect(host):
     logging.debug(f"[{host}] connecting to ssh directly")
     host.SshDirect.connect()
@@ -168,6 +172,7 @@ def init_proxy_container_and_connect(host):
     logging.debug(f"[{host}] connecting to ssh container")
     waiter.wait_nothrow(lambda: host.SSH.connect(port=host.tunnelport), timeout=60)
     logging.debug(f"[{host}] connected successfully")
+    check_hosts_file(host.SSH)
 
 
 def init_proxy_containers_and_connect(hosts):


### PR DESCRIPTION
docker hoster has a bug which if the hosts file is blank it gets an
exception. This causes the host with the product installed on it not to
have resolve for all the product dns's (memsql.tls.ai etc).

Im not sure what causes rare cases for the hosts file to be blank, but
when it happens it causes a lot of misunderstanding as to where the
problem is, because what fails at the end of the day is ping to one of
the servies, and there isnt an indicative error message. The solution is
to check if the file is blank and raise an indicative error.