### PR TITLE
Revert "set automation_proxy log level to DEBUG3"

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -39,8 +39,7 @@ RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/
     && sed -i 's/#MaxStartups.*/MaxStartups 512:30:1024/' /etc/ssh/sshd_config \
     && sed -i 's/#MaxSessions.*/MaxSessions 1024/' /etc/ssh/sshd_config \
     # SSH login fix. Otherwise user is kicked off after login
-    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
-    && sed -i 's/#LogLevel INFO/LogLevel DEBUG3/' /etc/ssh/sshd_config
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 # run as a different user
 


### PR DESCRIPTION
Reverts AnyVisionltd/automation-infra#292
This doesnt do anything, but if it does for some reason in the future it will f*ck up ssh connection bc on debug it only allows 1 concurrent connection so ssh and scp couldnt be active at the same time.