### PR TITLE
download_logs: redirect journal logs to file instead of downloading d…

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -318,8 +318,9 @@ def download_host_logs(host, logs_dir):
     dest_dir = os.path.join(logs_dir, host.alias)
     logging.debug(f"remote log folders and permissions: {host.SshDirect.execute('ls /storage/logs -lh || mkdir -p /storage/logs')}")
     host.SshDirect.execute('docker logs automation_proxy &> /tmp/automation_proxy.log')
+    host.SshDirect.execute('sudo sh -c "journalctl > /storage/logs/journal.log"')
     remote_log_folders = host.SshDirect.execute('ls /storage/logs').split()
-    paths_to_download = [*[f"/storage/logs/{folder}" for folder in remote_log_folders], '/var/log/journal', '/tmp/automation_proxy.log']
+    paths_to_download = [*[f"/storage/logs/{folder}" for folder in remote_log_folders], '/tmp/automation_proxy.log']
     logging.debug(f"Downloading logs from {host.alias} to {dest_dir}. Paths to download: {paths_to_download}")
     os.makedirs(dest_dir, exist_ok=True)
     host.SshDirect.download(re.escape(dest_dir), *paths_to_download)


### PR DESCRIPTION
…irectly

Up till now we would download journal logs by downloadingi the folder
/var/logs/journal. It turns out this folder is quite large (~20M),
whereas just redirecting journalctl is significantly smaller (~1M?) per
test. So better to download file instead of binary files from journal
folder.