### PR TITLE
Revert "docker-compose.yml: disable persistence on redis"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,3 @@ services:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
       - 6379:6379
-    command: [sh, -c, "rm -f /data/dump.rdb && redis-server"]  # disable persistence
-


### PR DESCRIPTION
This reverts commit 86ea1ff9e4930a0741cdf791ef845baafd48ddc1.
The reason for that is that if redis container restarts for any reason,
when there is no persistence all currently existing allocations will
disappear for the redis, which means that existing vms which were
allocated before the redis restart will never expire automatically. They
can still be manually released by the pytest which is running them when
the pytest finishes (hopefully) but in the case the process being killed
without sending a release command, the vms will stay dangling.

With persistent redis, the allocations will still exist even after redis
restart, which will then either continue receiving heartbeats or will
expire and releave relevant resources.