### PR TITLE
infra: fix version calculation

### DIFF
--- a/docker_build/version.sh
+++ b/docker_build/version.sh
@@ -5,7 +5,7 @@ function docker_tag () {
     local current_dir=$(dirname $current_file)
     local dockerfile=${current_dir}/Dockerfile
 
-    HASH_FILES=(${BASH_SOURCE[0]} $current_dir/requirements.txt $current_dir/docker_user.pem $current_dir/docker_user.pem.pub)
+    HASH_FILES=(${BASH_SOURCE[0]} ${dockerfile} $current_dir/requirements.txt $current_dir/docker_user.pem $current_dir/docker_user.pem.pub)
     HASH_FILES+=($(find $current_dir/etc/ -type f))
     local files_sum="$(md5sum -- ${HASH_FILES[@]} | awk {'print $1'})"
     local total_sum="$(echo -n $files_sum | md5sum | awk '{print substr($1,1,12)}')"


### PR DESCRIPTION
Currently version calculation does not take the docker file itself into
account. This lead to a situation where automation proxy container
changes in dockerfile but it is not reflected in the version. this leads
that tests are sometimes working and sometimes not (as proxy container
sometimes does not include required packages).
The solution is simply to include dockerfile in the calculation