### PR TITLE
docker-compose.yaml: added restart: always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=0
+    restart: always
     depends_on:
       - redis
     working_dir: /src
@@ -35,6 +36,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=0
+    restart: always
     depends_on:
       - redis
     command: watchmedo auto-restart --patterns="*.py;*.yaml;*.yml" --recursive -- python -m 'webapp.app' serve


### PR DESCRIPTION
This is so that if for some reason provisioner server restarts the
services will all start up on boot.