### PR TITLE
requirements3.txt: add pdbpp

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -95,3 +95,4 @@ ruamel.yaml==0.16.10
 ruamel.yaml.clib==0.2.0
 redis==3.5.3
 websocket-client==0.57.0
+pdb++


### PR DESCRIPTION
This module replaces pdb and will mean pytest with --pdb flag will drop
to ipdb instead of pdb, so with autocomplete etc etc.