### PR TITLE
Fixed host ip getter

### DIFF
--- a/pytest_automation_infra/helpers.py
+++ b/pytest_automation_infra/helpers.py
@@ -2,6 +2,7 @@ import logging
 import time
 import yaml
 import paramiko
+import socket
 
 from automation_infra.plugins.ssh_direct import SSHCalledProcessError
 import os
@@ -62,8 +63,11 @@ def do_docker_login(connected_ssh_module):
 
 
 def get_host_running_test_ip():
-    return os.getenv("host_ip",
-                     subprocess.check_output("hostname -I | awk '{print $1}'", shell=True).strip().decode('ascii'))
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    host_ip = s.getsockname()[0]
+    s.close()
+    return os.getenv("host_ip", host_ip)
 
 
 def create_secret(connected_ssh_module):


### PR DESCRIPTION
hostname -I command may contain a few IPs and there is no guarantee that the first one is your actual host IP address. It usually depends on wireless card. I use usb dongle and my host IP sits on the third place. Changed it to another approach to get it via socket which will work correctly with all the solutions