### PR TITLE
automation: expose allocation id for the tests.

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -225,6 +225,7 @@ def pytest_runtest_setup(item):
                                                   ep=os.getenv('HABERTEST_HEARTBEAT_SERVER', "http://localhost:7080"),
                                                   cert=os.getenv('HABERTEST_SSL_CERT', None),
                                                   key=os.getenv('HABERTEST_SSL_KEY', None))
+            os.environ["HABERTEST_ALLOCATION_ID"] =  hardware['allocation_id']
             hb.send_heartbeats_on_thread(hardware['allocation_id'])
             if determine_scope(None, item.config) == 'session':
                 item.session.__initialized_hardware = dict()


### PR DESCRIPTION
There are situations where test want to use "allocation id" as some id
of the running test (for example to mark resource usage) Of course this
is done only with allocated resources, so test has to make sure that it
can function without allocation id as well.