### PR TITLE
run/env_vars.sh: remove exit 0

### DIFF
--- a/run/env_vars.sh
+++ b/run/env_vars.sh
@@ -21,4 +21,3 @@ read -p "Change? waiting 5 seconds... (y) " -t 5 yn
               $prefix $@ ;;
 
   esac
-  exit 0


### PR DESCRIPTION
This must have been a type, it shouldnt have been there.. It will cause
the test run to exit with 0 exit code even if the tests failed.