### PR TITLE
provisioner: fix swallowing of errors in test

### DIFF
--- a/provisioner/__init__.py
+++ b/provisioner/__init__.py
@@ -21,7 +21,6 @@ def pytest_addoption(parser):
 
 
 def pytest_sessionstart(session):
-    session.kill_heartbeat = threading.Event()
     ssh_agent.setup_agent()
     provisioner = session.config.getoption("--provisioner")
     assert provisioner, "the following arguments are required: --provisioner"
@@ -58,7 +57,7 @@ def pytest_runtest_setup(item):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionfinish(session, exitstatus):
-    if not session.kill_heartbeat:
+    if not session.__initialized_hardware:
         return
     logging.debug("killing heartbeat")
     session.kill_heartbeat.set()


### PR DESCRIPTION
In the case there is a problem in one of the tests (say a bad import or
something like that) the error will be swallowed up by the error in
sessionfinish.
If I check for attribute __initialized_hardware instead of accessing it
directly the importError will permeate, rather than session has no
attribute kill_heartbeat.