### PR TITLE
pytest_automation_infra: bugfix for run/.local.sh

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -77,7 +77,6 @@ def determine_scope(fixture_name, config):
 
 def configured_hardware(request):
     return getattr(request.session, "__initialized_hardware", None) \
-           or getattr(request.module, "__initialized_hardware", None) \
            or getattr(request.function, "__initialized_hardware", None)
 
 
@@ -150,7 +149,7 @@ def pytest_runtest_setup(item):
         logging.info("getting locally configured hardware")
         hardware = dict()
         hardware['machines'] = get_local_config(item.config.getoption("--hardware"))
-        item.function.__initialized_hardware = hardware
+        item.session.__initialized_hardware = hardware
 
     hardware = configured_hardware(item._request)
     assert hardware, "Couldnt find configured hardware in pytest_runtest_setup"


### PR DESCRIPTION
Because item.session.__initialized_hardware wasnt set
configured_hardware would try to access module scoped hardware, which
while running with session scoped fixture throws an exception.

The solution is to add initialized_hardware to the session instead of
the function, and in addition I removed checking for module hardware as
that is deprecated functionality which we decided against using.