### PR TITLE
provisioner_client: socket.gaierror: [Errno -2] Name or service not k…

### DIFF
--- a/pytest_automation_infra/provisioner_client.py
+++ b/pytest_automation_infra/provisioner_client.py
@@ -45,9 +45,11 @@ class ProvisionerClient(object):
         allocation_id = str(uuid.uuid4())
         logging.info(f"allocation_id: {allocation_id}")
         while time.time() - start <= timeout:
-            requestor_information = dict(hostname=os.getenv("host_hostname", socket.gethostname()),
+            hostname = os.getenv("host_hostname") if os.getenv("host_hostname") else socket.gethostname()
+            ip = os.getenv("host_ip") if os.getenv("host_ip") else socket.gethostbyname(socket.gethostname())
+            requestor_information = dict(hostname=hostname,
                                          username=getpass.getuser(),
-                                         ip=os.getenv("host_ip", socket.gethostbyname(socket.gethostname())),
+                                         ip=ip,
                                          external_ip=self.external_ip,
                                          creation_time=str(datetime.now()),
                                          running_cmd=" ".join(sys.argv)


### PR DESCRIPTION
…nown bugfix

os.getenv has a weird behaviour that even if the env variable exists, it
still evaluates the default value given. On our jenkinsslave we were
getting socket.gaierror: [Errno -2] Name or service not known because
the hostname was slave-anyvision-il-officeslave-anyvision-il-office
which wasnt resolvable.

The solution is just to calculate the default value if the env variable
doesnt exist, which is easily done with the python ternary syntax.