### PR TITLE
added user path into pypacker.py in order not to pack standards libra…

### DIFF
--- a/automation_infra/utils/pypacker.py
+++ b/automation_infra/utils/pypacker.py
@@ -78,6 +78,7 @@ class PythonPacker(object):
         stdlib = sysconfig.get_python_lib(standard_lib=True)
         stdlib_local = sysconfig.get_python_lib(standard_lib=True, prefix='/usr/local')
         dist_packages = sysconfig.get_python_lib()
+        stdlib_user_local = sysconfig.get_python_lib(standard_lib=True, prefix=f'{os.path.expanduser("~")}/.local')
         for module in finder.modules.values():
             if module.__file__ is None:
                 continue
@@ -86,6 +87,8 @@ class PythonPacker(object):
             elif module.__file__.startswith(stdlib_local):
                 continue
             elif module.__file__.startswith(dist_packages):
+                continue
+            elif module.__file__.startswith(stdlib_user_local):
                 continue
             elif module.__file__ == buffer.name:
                 continue


### PR DESCRIPTION
The problem: snippet with virtualenv copies in standard libraries when it shouldn't
the problem is in the function:
infra/utils/pypacker/_modules_from_buffer

We weren't able to successfully identify standard libraries, and then they are yielded and packed, and send across on the egg file, causing failure

added user path into pypacker.py in order not to pack standards libraries