### PR TITLE
make relative symlink instead of absolute path

### DIFF
--- a/pytest_subprocessor/serializer.py
+++ b/pytest_subprocessor/serializer.py
@@ -83,4 +83,4 @@ def create_symbolic_link(item, outcome):
     dest = os.path.realpath(os.path.join(by_outcome_dir, sanitize_nodeid(os.path.split(item.nodeid)[1])))
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     if not os.path.exists(dest):
-        os.symlink(item_logs_dir, dest, target_is_directory=True)
+        os.symlink(os.path.relpath(item_logs_dir, os.path.dirname(dest)), dest, target_is_directory=True)


### PR DESCRIPTION
when moving a folder containing an absolute path symlink the link gets
broken. If the relative directory structure of the symlink is moved
completely as a whole, the symlink will continue to function.

When running tests via jenkins, the last step is to copy the logs folder
to an artifact folder, so the absolute path symlinks were getting
broken.

The solution is to use a relative path symlink.