### PR TITLE
set threadname to worker id

### DIFF
--- a/pytest_provisioner/grouper_hooks.py
+++ b/pytest_provisioner/grouper_hooks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 
 import pytest
 
@@ -22,7 +23,8 @@ def pytest_can_run_together(item1, item2):
 
 def pytest_started_handling_group(session, worker):
     worker.refresh_id()
-    logging.info("worker started handling group")
+    logging.info(f"worker refreshed her id to: {worker.id}")
+    threading.current_thread().setName(worker.id)
 
 
 def pytest_finished_handling_group(session, worker):

--- a/pytest_subprocessor/worker.py
+++ b/pytest_subprocessor/worker.py
@@ -22,7 +22,7 @@ class Worker:
         self.id = str(uuid.uuid4())
         self.session = session
         self.fut = None
-        self.executor = ThreadPoolExecutor(max_workers=1)
+        self.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=self.id,)
         self.handled_items = list()
 
     def start(self):


### PR DESCRIPTION
Otherwise when running tests in parallel its impossible to discover
which log comes from which worker.