### PR TITLE
Cluster grouping: Fixed hosts cluster grouping

### DIFF
--- a/pytest_automation_infra/__init__.py
+++ b/pytest_automation_infra/__init__.py
@@ -179,8 +179,8 @@ def init_cluster_structure(base_config, cluster_config):
     base_config.clusters = Munch()
     if cluster_config is None:
         return
-    for cluster_name, hosts_dict in cluster_config.items():
-        hostnames = [hostname for hostname in base_config.hosts.keys()]
+    for cluster_name, config in cluster_config.items():
+        hostnames = config['hosts']
         hosts_dict = dict()
         for hostname in hostnames:
             host = base_config.hosts[hostname]


### PR DESCRIPTION
This commits fixes hosts cluster grouping which
didn't work as expected:

hostnames were taken from base_config.hosts resulted with
every cluster groups the entire hosts listed in harware config.

This commit fixes this issue and groups only the hosts that are lister
under a cluster group